### PR TITLE
Change main to fix incorrect filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "type": "git",
     "url": "git://github.com/liblouis/js-build.git"
   },
-  "main": "./build-no-tables-utf16.js"
+  "main": "./build-no-tables-utf32.js"
 }


### PR DESCRIPTION
Builds changed from utf16 to utf32 at some point, but main was not updated to match new filename.